### PR TITLE
Allow templates to exclude from_email

### DIFF
--- a/flask_mandrill.py
+++ b/flask_mandrill.py
@@ -50,7 +50,7 @@ class Mandrill(object):
                 self.app.config.get('MANDRILL_DEFAULT_FROM', None)
             )
 
-        if not data['message'].get('from_email', None):
+        if endpoint != self.templates_endpoint and not data['message'].get('from_email', None):
             raise ValueError(
                 'No from email was specified and no default was configured')
 


### PR DESCRIPTION
You can specify a default from email address in mandrill templates. Let
the API response fail instead of doing the client-side check in this
case.